### PR TITLE
Bl808/board add i2c busses to the device tree

### DIFF
--- a/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
@@ -18,7 +18,7 @@
 
 	chosen {
 		stdout-path = "serial0:2000000n8";
-		bootargs = "console=ttyS0,2000000 loglevel=8 earlycon=sbi root=/dev/mmcblk0p2 rootwait rootfstype=ext4";
+		bootargs = "console=ttyS0,2000000 loglevel=8 earlycon=sbi root=PARTLABEL=rootfs rootwait rootfstype=ext4";
 		linux,initrd-start = <0x0 0x52000000>;
 		linux,initrd-end = <0x0 0x52941784>;
 	};

--- a/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
@@ -41,10 +41,22 @@
 
 &pinctrl {
 	status = "okay";
+
+	i2c_2_pins: i2c-pins {
+		pins = "GPIO6", "GPIO7";
+		function = "i2c2";
+	};
 };
 
 &seceng {
 	status = "okay";
+};
+
+&i2c2 {
+	status = "okay";
+
+	pinctrl-0 = <&i2c_2_pins>;
+	pinctrl-names = "default";
 };
 
 &uart0 {

--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -52,6 +52,20 @@
 		#clock-cells = <0>;
 	};
 
+	rc32m: rc32m-clk {
+		compatible = "fixed-clock";
+		clock-frequency = <32000000>;
+		clock-output-names = "rc32m";
+		#clock-cells = <0>;
+	};
+
+	mm_b: mm_bclk1x {
+		compatible = "fixed-clock";
+		clock-frequency = <160000000>;
+		clock-output-names = "mm_b";
+		#clock-cells = <0>;
+	};
+
 	enet: enet-clk {
 		compatible = "fixed-clock";
 		clock-frequency = <50000000>;
@@ -94,6 +108,48 @@
 		seceng: seceng@0x20004000 {
 			compatible = "bflb,seceng";
 			reg = <0x20004000 0x1000>;
+			status = "disabled";
+		};
+
+		i2c0: i2c@2000A300 {
+			compatible = "bflb,bl808-i2c";
+			reg = <0x2000A300 0x0100>;
+			interrupts-extended = <&ipclic BFLB_IPC_SOURCE_M0
+								BFLB_IPC_DEVICE_I2C0
+								IRQ_TYPE_EDGE_RISING>;
+			mboxes = <&ipclic BFLB_IPC_SOURCE_M0 BFLB_IPC_DEVICE_I2C0>;
+			clocks = <&rc32m>;
+			clock-frequency = <400000>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@2000A900 {
+			compatible = "bflb,bl808-i2c";
+			reg = <0x2000A900 0x0100>;
+			interrupts-extended = <&ipclic BFLB_IPC_SOURCE_M0
+								BFLB_IPC_DEVICE_I2C1
+								IRQ_TYPE_EDGE_RISING>;
+			mboxes = <&ipclic BFLB_IPC_SOURCE_M0 BFLB_IPC_DEVICE_I2C1>;
+			clocks = <&rc32m>;
+			clock-frequency = <400000>;
+			status = "disabled";
+		};
+
+		i2c2: i2c@30003000 {
+			compatible = "bflb,bl808-i2c";
+			reg = <0x30003000 0x1000>;
+			interrupts = <21 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&mm_b>;
+			clock-frequency = <400000>;
+			status = "disabled";
+		};
+
+		i2c3: i2c@30004000 {
+			compatible = "bflb,bl808-i2c";
+			reg = <0x30004000 0x1000>;
+			interrupts = <22 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&mm_b>;
+			clock-frequency = <400000>;
 			status = "disabled";
 		};
 

--- a/include/dt-bindings/mailbox/bflb-ipc.h
+++ b/include/dt-bindings/mailbox/bflb-ipc.h
@@ -16,5 +16,7 @@
 #define BFLB_IPC_DEVICE_USB		    2
 #define BFLB_IPC_DEVICE_EMAC		3
 #define BFLB_IPC_DEVICE_GPIO        4
+#define BFLB_IPC_DEVICE_I2C0        5
+#define BFLB_IPC_DEVICE_I2C1        6
 
 #endif


### PR DESCRIPTION
This PR adds the i2c bus entries to the devicetree of the bl808 soc